### PR TITLE
Wrong date format fix

### DIFF
--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/util/DateUtil.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/util/DateUtil.java
@@ -25,7 +25,7 @@ public class DateUtil {
         try {
             DateFormat f = new SimpleDateFormat("E MMM dd HH:mm:ss zzz yyyy");
             Date d = f.parse(date.toString());
-            DateFormat out = new SimpleDateFormat("YYYY-DD-MM");
+            DateFormat out = new SimpleDateFormat("YYYY-dd-MM");
             return out.format(d);
 
         } catch (ParseException ex) {


### PR DESCRIPTION
The current date format is incorrect. 

For example, Wed May 05 01:31:11 COT 2021, with format "YYYY-DD-MM" produces: 2021-131-05
The correct one is "YYYY-dd-MM", which produces: 2021-11-05

