### PR TITLE
Item class and item fields sort order fix

### DIFF
--- a/dist/app/re3gistry2/jsp/field.jsp
+++ b/dist/app/re3gistry2/jsp/field.jsp
@@ -332,7 +332,7 @@
                     of the RegField, activating the function --%>
                     <% if (permissionManageFieldMapping) { %>
                     rowReorder: true,
-                            columnDefs: [{orderable: true, className: 'reorder', targets: 0 }],
+                            columnDefs: [{orderable: true, className: 'reorder', targets: 0, type: 'num-fmt' }],
                     <% } %>
                     "columns": [null, { "width": "16%" }, null, null, null, null, null, null, null],
                     'drawCallback': function () {

--- a/dist/app/re3gistry2/jsp/itemclass.jsp
+++ b/dist/app/re3gistry2/jsp/itemclass.jsp
@@ -165,7 +165,7 @@
             of the RegItemclass, activating the function --%>
             <% if (permissionRegisterRegistry) { %>
             rowReorder: true,
-                    columnDefs: [{orderable: true, className: 'reorder', targets: 0
+                    columnDefs: [{orderable: true, className: 'reorder', targets: 0, type: 'num-fmt'
                     }
                     ],
             <% } %>


### PR DESCRIPTION
When there are more than 10 items classes or items fields, field.jsp and itemclass.jsp doesn't order correctly the items/fields (by default uses string based order [ie: 1, 10, 11, 2, 3, 4...]. This issue generates inconsistencies when rows are reordered.