### PR TITLE
Update comment regarding ecas-tomcat-7.0-4.26.0.jar

### DIFF
--- a/sources/Re3gistry2Base/pom.xml
+++ b/sources/Re3gistry2Base/pom.xml
@@ -29,7 +29,7 @@
             <scope>provided</scope>
         </dependency>-->
         <dependency>
-            <!-- if not available in the local repository, try to execute the "validate" goal configurated in this POM -->
+            <!-- if not available in the local repository, execute the "initialize" goal configured in this POM -->
             <groupId>eu.cec.digit.ecas</groupId>
             <artifactId>ecas-tomcat-7.0</artifactId>
             <version>4.26.0</version>


### PR DESCRIPTION
Update comment: ecas-tomcat-7.0-4.26.0.jar is installed when executing the "initialize" phase, not when executing the "validate" phase ([and the "initialize" phase is after the "validate" phase).](http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference)