### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ local.properties
 
 # Added, not from https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/Eclipse.gitignore
 .classpath
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# From https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/Eclipse.gitignore
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+.project
+
+
+# Added, not from https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/Eclipse.gitignore
+.classpath


### PR DESCRIPTION
Add .gitignore file that ignores Eclipse-files (.project, .classpath
.settings, etc.); based on
https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/Eclipse.gitignore

Reason: after checking out the repo, importing it in Eclipse, and executing `git status`, I got:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        sources/Re3gistry2-build-helper/.project
        sources/Re3gistry2-build-helper/.settings/
        sources/Re3gistry2/.classpath
        sources/Re3gistry2/.project
        sources/Re3gistry2/.settings/
        sources/Re3gistry2Base/.classpath
        sources/Re3gistry2Base/.project
        sources/Re3gistry2Base/.settings/
        sources/Re3gistry2CRUDinterface/.classpath
        sources/Re3gistry2CRUDinterface/.project
        sources/Re3gistry2CRUDinterface/.settings/
        sources/Re3gistry2CRUDrdb/.classpath
        sources/Re3gistry2CRUDrdb/.project
        sources/Re3gistry2CRUDrdb/.settings/
        sources/Re3gistry2JavaAPI/.classpath
        sources/Re3gistry2JavaAPI/.project
        sources/Re3gistry2JavaAPI/.settings/
        sources/Re3gistry2Migration/.classpath
        sources/Re3gistry2Migration/.project
        sources/Re3gistry2Migration/.settings/
        sources/Re3gistry2Model/.classpath
        sources/Re3gistry2Model/.project
        sources/Re3gistry2Model/.settings/
        sources/Re3gistry2RestAPI/.classpath
        sources/Re3gistry2RestAPI/.project
        sources/Re3gistry2RestAPI/.settings/
```

After committing the .gitignore file, .classpath, .project, .settings/, etc. are ignored, and I get:

`nothing to commit, working tree clean`