### PR TITLE
Improve error logging

### DIFF
--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/About.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/About.java
@@ -51,7 +51,7 @@ public class About extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
     
@@ -61,7 +61,7 @@ public class About extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ActionDetail.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ActionDetail.java
@@ -62,7 +62,7 @@ public class ActionDetail extends HttpServlet {
         try {
             regAction = regActionManager.get(actionUUID);
         } catch (NoResultException e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         }
 
         // Setting the RegAction parameter
@@ -79,7 +79,7 @@ public class ActionDetail extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -89,7 +89,7 @@ public class ActionDetail extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddField.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddField.java
@@ -194,7 +194,7 @@ public class AddField extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -204,7 +204,7 @@ public class AddField extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldParent.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldParent.java
@@ -153,7 +153,7 @@ public class AddFieldParent extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -163,7 +163,7 @@ public class AddFieldParent extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldRelation.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldRelation.java
@@ -136,7 +136,7 @@ public class AddFieldRelation extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -146,7 +146,7 @@ public class AddFieldRelation extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldValue.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddFieldValue.java
@@ -52,7 +52,7 @@ public class AddFieldValue extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -62,7 +62,7 @@ public class AddFieldValue extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddItem.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddItem.java
@@ -231,7 +231,7 @@ public class AddItem extends HttpServlet {
                         } catch (Exception e) {
                             String operationResult = e.getMessage();
                             request.setAttribute(BaseConstants.KEY_REQUEST_OPERATIONRESULT, operationResult);
-                            logger.error(e);
+                            logger.error(e.getMessage(), e);
                         }
 
                         // Redirecting to the Item container page
@@ -299,7 +299,7 @@ public class AddItem extends HttpServlet {
                 // Redirecting to the Item container page
                 response.sendRedirect("." + WebConstants.PAGE_URINAME_BROWSE + "?" + BaseConstants.KEY_REQUEST_ITEMUUID + "=" + itemUuid);
             } catch (Exception e) {
-                logger.error(e.getMessage());
+                logger.error(e.getMessage(), e);
             }
         } else {
             response.sendRedirect("." + WebConstants.PAGE_URINAME_BROWSE);
@@ -312,7 +312,7 @@ public class AddItem extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -322,7 +322,7 @@ public class AddItem extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddItemclass.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddItemclass.java
@@ -171,7 +171,7 @@ public class AddItemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -181,7 +181,7 @@ public class AddItemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddRegister.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddRegister.java
@@ -163,7 +163,7 @@ public class AddRegister extends HttpServlet {
                     }
 
                 } catch (NoResultException e) {
-                    logger.error(e.getMessage());
+                    logger.error(e.getMessage(), e);
                     // Setting the operation success attribute
                     operationResult = localization.getString("error.generic");
                     request.setAttribute(BaseConstants.KEY_REQUEST_OPERATIONRESULT, operationResult);
@@ -231,7 +231,7 @@ public class AddRegister extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -241,7 +241,7 @@ public class AddRegister extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddSuccessor.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/AddSuccessor.java
@@ -95,7 +95,7 @@ public class AddSuccessor extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -105,7 +105,7 @@ public class AddSuccessor extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Browse.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Browse.java
@@ -90,7 +90,7 @@ public class Browse extends HttpServlet {
             mainRegistryItemclassLocalId = properties.getProperty("application.multiregistry.mainregistryitemclasslocalid");
             mainRegistryLocalId = properties.getProperty("application.multiregistry.mainregistrylocalid");
         } catch (Exception e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
 
         // Setup the entity manager
@@ -310,7 +310,7 @@ public class Browse extends HttpServlet {
                     try {
                         regItemproposedHandler.handleRegItemproposedSave(requestParameters, regUser);
                     } catch (Exception e) {
-                        logger.error(e);
+                        logger.error(e.getMessage(), e);
                         saveError = true;
                     }
                 } else if (regItemproposed != null && ( // Permission to edit Registers and items
@@ -328,7 +328,7 @@ public class Browse extends HttpServlet {
                     try {
                         regItemproposedHandler.handleRegItemproposedNewSave(requestParameters, regUser);
                     } catch (Exception e) {
-                        logger.error(e);
+                        logger.error(e.getMessage(), e);
                         saveError = true;
                     }
                 }
@@ -385,7 +385,7 @@ public class Browse extends HttpServlet {
                 }
             }
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             response.sendRedirect(".");
         } finally {
             if (entityManager.isOpen()) {
@@ -404,7 +404,7 @@ public class Browse extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -414,7 +414,7 @@ public class Browse extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/BrowseLoader.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/BrowseLoader.java
@@ -133,7 +133,7 @@ public class BrowseLoader extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -143,7 +143,7 @@ public class BrowseLoader extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/BrowseLoaderNewProposal.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/BrowseLoaderNewProposal.java
@@ -99,7 +99,7 @@ public class BrowseLoaderNewProposal extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -109,7 +109,7 @@ public class BrowseLoaderNewProposal extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ChangeLocale.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ChangeLocale.java
@@ -61,7 +61,7 @@ public class ChangeLocale extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -71,7 +71,7 @@ public class ChangeLocale extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ControlBody.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ControlBody.java
@@ -230,7 +230,7 @@ public class ControlBody extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -240,7 +240,7 @@ public class ControlBody extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/DiscardProposal.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/DiscardProposal.java
@@ -143,7 +143,7 @@ public class DiscardProposal extends HttpServlet {
                     redirectURI = "." + WebConstants.PAGE_PATH_SUBMITTINGORGANISATIONS + WebConstants.PAGE_URINAME_SUBMITTINGORGANISATIONS;
 //                    request.getRequestDispatcher(WebConstants.PAGE_JSP_FOLDER + WebConstants.PAGE_PATH_SUBMITTINGORGANISATIONS + WebConstants.PAGE_URINAME_SUBMITTINGORGANISATIONS + WebConstants.PAGE_JSP_EXTENSION).forward(request, response);
                 } catch (NoResultException e) {
-                    logger.error(e);
+                    logger.error(e.getMessage(), e);
                 }
             } else //                    discard item
             if (regItemproposedUUID != null && !regItemproposedUUID.isEmpty()) {
@@ -233,7 +233,7 @@ public class DiscardProposal extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -243,7 +243,7 @@ public class DiscardProposal extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/DynamicCommonJavascript.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/DynamicCommonJavascript.java
@@ -51,7 +51,7 @@ public class DynamicCommonJavascript extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -61,7 +61,7 @@ public class DynamicCommonJavascript extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/EditItemclass.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/EditItemclass.java
@@ -121,7 +121,7 @@ public class EditItemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -131,7 +131,7 @@ public class EditItemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Field.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Field.java
@@ -233,7 +233,7 @@ public class Field extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -243,7 +243,7 @@ public class Field extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/FieldLoader.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/FieldLoader.java
@@ -107,7 +107,7 @@ public class FieldLoader extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -117,7 +117,7 @@ public class FieldLoader extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Help.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Help.java
@@ -51,7 +51,7 @@ public class Help extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
     
@@ -61,7 +61,7 @@ public class Help extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Index.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Index.java
@@ -51,7 +51,7 @@ public class Index extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
     
@@ -61,7 +61,7 @@ public class Index extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
@@ -152,7 +152,7 @@ public class Install extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -162,7 +162,7 @@ public class Install extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/InstallRunning.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/InstallRunning.java
@@ -50,7 +50,7 @@ public class InstallRunning extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -60,7 +60,7 @@ public class InstallRunning extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemChildrenListLoaderServlet.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemChildrenListLoaderServlet.java
@@ -600,7 +600,7 @@ public class ItemChildrenListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -610,7 +610,7 @@ public class ItemChildrenListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemListLoaderServlet.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemListLoaderServlet.java
@@ -617,7 +617,7 @@ public class ItemListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -627,7 +627,7 @@ public class ItemListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemListUserActivity.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemListUserActivity.java
@@ -172,7 +172,7 @@ public class ItemListUserActivity extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -182,7 +182,7 @@ public class ItemListUserActivity extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemProposedListLoaderServlet.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ItemProposedListLoaderServlet.java
@@ -581,7 +581,7 @@ public class ItemProposedListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -591,7 +591,7 @@ public class ItemProposedListLoaderServlet extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Itemclass.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Itemclass.java
@@ -208,7 +208,7 @@ public class Itemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -218,7 +218,7 @@ public class Itemclass extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Login.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Login.java
@@ -60,7 +60,7 @@ public class Login extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -70,7 +70,7 @@ public class Login extends HttpServlet {
             processRequest(request, response);
         }catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Logout.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Logout.java
@@ -91,7 +91,7 @@ public class Logout extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -101,7 +101,7 @@ public class Logout extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/MapField.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/MapField.java
@@ -196,7 +196,7 @@ public class MapField extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -206,7 +206,7 @@ public class MapField extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegisterManager.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegisterManager.java
@@ -217,7 +217,7 @@ public class RegisterManager extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -227,7 +227,7 @@ public class RegisterManager extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManager.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManager.java
@@ -219,7 +219,7 @@ public class RegistryManager extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -229,7 +229,7 @@ public class RegistryManager extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerDataExport.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerDataExport.java
@@ -122,7 +122,7 @@ public class RegistryManagerDataExport extends HttpServlet {
                 request.getRequestDispatcher(WebConstants.PAGE_JSP_FOLDER + WebConstants.PAGE_PATH_REGISTRYMANAGER_DATAEXPORT + WebConstants.PAGE_URINAME_REGISTRYMANAGER_DATAEXPORT + WebConstants.PAGE_JSP_EXTENSION).forward(request, response);
 
             } catch (Exception e) {
-                logger.error(e);
+                logger.error(e.getMessage(), e);
                 // Redirecting to the RegItemclasses list page
                 response.sendRedirect("." + WebConstants.PAGE_PATH_INDEX + WebConstants.PAGE_URINAME_INDEX);
             }
@@ -137,7 +137,7 @@ public class RegistryManagerDataExport extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -147,7 +147,7 @@ public class RegistryManagerDataExport extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerGroups.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerGroups.java
@@ -148,7 +148,7 @@ public class RegistryManagerGroups extends HttpServlet {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage());
+                    logger.error(e.getMessage(), e);
                 }
                 request.setAttribute(BaseConstants.KEY_REQUEST_RESULT, result);
             }
@@ -196,7 +196,7 @@ public class RegistryManagerGroups extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -206,7 +206,7 @@ public class RegistryManagerGroups extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerGroupsAdd.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerGroupsAdd.java
@@ -143,7 +143,7 @@ public class RegistryManagerGroupsAdd extends HttpServlet {
                     result = regGroupHandler.addGroup(newGroup,regUser);
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage());
+                    logger.error(e.getMessage(), e);
                 }
                 request.setAttribute(BaseConstants.KEY_REQUEST_RESULT, result);
             }
@@ -173,7 +173,7 @@ public class RegistryManagerGroupsAdd extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -183,7 +183,7 @@ public class RegistryManagerGroupsAdd extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerUsers.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerUsers.java
@@ -180,7 +180,7 @@ public class RegistryManagerUsers extends HttpServlet {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e);
+                    logger.error(e.getMessage(), e);
                 }
                 request.setAttribute(BaseConstants.KEY_REQUEST_RESULT, result);
             }
@@ -219,7 +219,7 @@ public class RegistryManagerUsers extends HttpServlet {
                 request.getRequestDispatcher(WebConstants.PAGE_JSP_FOLDER + WebConstants.PAGE_PATH_REGISTRYMANAGER_USERS + WebConstants.PAGE_URINAME_REGISTRYMANAGER_USERS + WebConstants.PAGE_JSP_EXTENSION).forward(request, response);
 
             } catch (Exception e) {
-                logger.error(e);
+                logger.error(e.getMessage(), e);
                 // Redirecting to the RegItemclasses list page
                 response.sendRedirect("." + WebConstants.PAGE_PATH_INDEX + WebConstants.PAGE_URINAME_INDEX);
             }
@@ -234,7 +234,7 @@ public class RegistryManagerUsers extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -244,7 +244,7 @@ public class RegistryManagerUsers extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerUsersAdd.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RegistryManagerUsersAdd.java
@@ -234,7 +234,7 @@ public class RegistryManagerUsersAdd extends HttpServlet {
                         }
                     }
                 } catch (Exception e) {
-                    logger.error(e.getMessage());
+                    logger.error(e.getMessage(), e);
                 }
                 request.setAttribute(BaseConstants.KEY_REQUEST_RESULT, result);
             }
@@ -268,7 +268,7 @@ public class RegistryManagerUsersAdd extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -278,7 +278,7 @@ public class RegistryManagerUsersAdd extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RemoveFieldValue.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RemoveFieldValue.java
@@ -246,7 +246,7 @@ public class RemoveFieldValue extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -256,7 +256,7 @@ public class RemoveFieldValue extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ResetPassword.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/ResetPassword.java
@@ -141,7 +141,7 @@ public class ResetPassword extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -151,7 +151,7 @@ public class ResetPassword extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RestoreOriginalRelation.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/RestoreOriginalRelation.java
@@ -171,7 +171,7 @@ public class RestoreOriginalRelation extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -181,7 +181,7 @@ public class RestoreOriginalRelation extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Status.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Status.java
@@ -116,7 +116,7 @@ public class Status extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -126,7 +126,7 @@ public class Status extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/StatusChange.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/StatusChange.java
@@ -183,7 +183,7 @@ public class StatusChange extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -193,7 +193,7 @@ public class StatusChange extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/SubmittingOrganisations.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/SubmittingOrganisations.java
@@ -295,7 +295,7 @@ public class SubmittingOrganisations extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -305,7 +305,7 @@ public class SubmittingOrganisations extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/UserProfile.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/UserProfile.java
@@ -174,7 +174,7 @@ public class UserProfile extends HttpServlet {
                     request.getRequestDispatcher(WebConstants.PAGE_JSP_FOLDER + WebConstants.PAGE_PATH_USERPROFILE + WebConstants.PAGE_URINAME_USERPROFILE + WebConstants.PAGE_JSP_EXTENSION).forward(request, response);
 
                 } catch (Exception e) {
-                    logger.error(e);
+                    logger.error(e.getMessage(), e);
                     // Redirecting to the index page
                     response.sendRedirect("." + WebConstants.PAGE_PATH_INDEX + WebConstants.PAGE_URINAME_INDEX);
                 }
@@ -208,7 +208,7 @@ public class UserProfile extends HttpServlet {
                 request.getRequestDispatcher(WebConstants.PAGE_JSP_FOLDER + WebConstants.PAGE_PATH_REGISTRYMANAGER_USERS + WebConstants.PAGE_URINAME_REGISTRYMANAGER_USERS + WebConstants.PAGE_JSP_EXTENSION).forward(request, response);
 
             } catch (Exception e) {
-                logger.error(e);
+                logger.error(e.getMessage(), e);
                 // Redirecting to the RegItemclasses list page
                 response.sendRedirect("." + WebConstants.PAGE_PATH_INDEX + WebConstants.PAGE_URINAME_INDEX);
             }
@@ -224,7 +224,7 @@ public class UserProfile extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -234,7 +234,7 @@ public class UserProfile extends HttpServlet {
             processRequest(request, response);
         } catch (Exception ex) {
             Logger logger = Configuration.getInstance().getLogger();
-            logger.error(ex);
+            logger.error(ex.getMessage(), ex);
         }
     }
 }

--- a/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/Configuration.java
+++ b/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/Configuration.java
@@ -120,7 +120,7 @@ public class Configuration {
             }
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         }
         return installed;
     }
@@ -136,7 +136,7 @@ public class Configuration {
             }
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         }
         return installing;
     }

--- a/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/MailManager.java
+++ b/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/MailManager.java
@@ -153,7 +153,7 @@ public class MailManager {
             Transport.send(msg);
 
         } catch (MessagingException e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
             throw new MessagingException(e.getMessage());
         }
     }

--- a/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/RegistryRealm.java
+++ b/sources/Re3gistry2Base/src/main/java/eu/europa/ec/re3gistry2/base/utility/RegistryRealm.java
@@ -57,7 +57,7 @@ public class RegistryRealm extends JdbcRealm {
                 user = regUserManager.findByEmail(username);
             } catch (Exception ex) {
                 user = null;
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
             }
 
             if (user == null) {
@@ -70,7 +70,7 @@ public class RegistryRealm extends JdbcRealm {
 
             return info;
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             return null;
         }
     }

--- a/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegActionHandler.java
+++ b/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegActionHandler.java
@@ -137,7 +137,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -238,7 +238,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -278,7 +278,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -354,7 +354,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -434,7 +434,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 if (entityManager.isOpen()) {
@@ -465,7 +465,7 @@ public class RegActionHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();

--- a/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegInstallationHandler.java
+++ b/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegInstallationHandler.java
@@ -549,7 +549,7 @@ public class RegInstallationHandler {
                     }
 
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             }
@@ -668,11 +668,11 @@ public class RegInstallationHandler {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }

--- a/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegItemclassHandler.java
+++ b/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegItemclassHandler.java
@@ -359,7 +359,7 @@ public class RegItemclassHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -427,7 +427,7 @@ public class RegItemclassHandler {
             if (entityManager != null) {
                 entityManager.getTransaction().rollback();
             }
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();

--- a/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegItemproposedHandler.java
+++ b/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/handler/RegItemproposedHandler.java
@@ -450,7 +450,7 @@ public class RegItemproposedHandler {
             }
             /* ## End Synchronized ## */
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         } finally {
             if (entityManager != null) {
                 entityManager.close();
@@ -958,7 +958,7 @@ public class RegItemproposedHandler {
 
         } catch (NoResultException e) {
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         } finally {
             entityManager.close();
         }
@@ -1501,7 +1501,7 @@ public class RegItemproposedHandler {
             } catch (NoResultException e) {
                 // The form field is not a RegField: no action needed
             } catch (Exception e) {
-                logger.error(e.getMessage());
+                logger.error(e.getMessage(), e);
             }
         }
 

--- a/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/solr/SolrHandler.java
+++ b/sources/Re3gistry2JavaAPI/src/main/java/eu/europa/ec/re3gistry2/javaapi/solr/SolrHandler.java
@@ -107,7 +107,7 @@ public class SolrHandler {
             return true;
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             deleteSolrCompleteIndexinglRunningFile();
             return false;
         }
@@ -140,7 +140,7 @@ public class SolrHandler {
             return true;
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             deleteSolrCompleteIndexinglRunningFile();
             return false;
         }
@@ -173,7 +173,7 @@ public class SolrHandler {
                     .build();
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             return null;
         }
     }
@@ -317,7 +317,7 @@ public class SolrHandler {
             return documents;
 
         } catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             return null;
         }
     }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/handler/RegInstallationStepMigrationPorcessHandler.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/handler/RegInstallationStepMigrationPorcessHandler.java
@@ -80,7 +80,7 @@ public class RegInstallationStepMigrationPorcessHandler {
             }
             entityManagerRe3gistry2.getTransaction().commit();
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
 

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateExtensiblityAndGovernanceLevel.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateExtensiblityAndGovernanceLevel.java
@@ -556,7 +556,7 @@ public class MigrateExtensiblityAndGovernanceLevel {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
 

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItemHistory.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItemHistory.java
@@ -225,7 +225,7 @@ public class MigrateItemHistory {
                     }
 
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
 
                 }
@@ -419,7 +419,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
 
@@ -453,7 +453,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -489,11 +489,11 @@ public class MigrateItemHistory {
 //                    entityManagerRe3gistry2.getTransaction().commit();
 //                }
 //            } catch (Exception ex) {
-//                logger.error(ex.getMessage());
+//                logger.error(ex.getMessage(), ex);
 //                throw new Exception(ex.getMessage());
 //            }
 //        } catch (Exception ex) {
-////            logger.error(ex.getMessage());
+////            logger.error(ex.getMessage(), ex);
 ////            throw new Exception(ex.getMessage());
 //        }
 //    }
@@ -523,11 +523,11 @@ public class MigrateItemHistory {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         }
@@ -557,11 +557,11 @@ public class MigrateItemHistory {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         }
@@ -580,7 +580,7 @@ public class MigrateItemHistory {
             migratePredecessorHistory(regItemManager, createSuccessorUuid, regRelationpredicateManager, regItemhistory, commit);
 
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
 //            throw new Exception(ex.getMessage());
         }
     }
@@ -605,7 +605,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -629,7 +629,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return createSuccessorUuid;
@@ -664,11 +664,11 @@ public class MigrateItemHistory {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -702,11 +702,11 @@ public class MigrateItemHistory {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -751,7 +751,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return regItemhistory;
@@ -800,7 +800,7 @@ public class MigrateItemHistory {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return regItemhistory;

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItemLatestVersion.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItemLatestVersion.java
@@ -325,7 +325,7 @@ public class MigrateItemLatestVersion {
                     }
 
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                 }
             } else {
                 /**
@@ -569,10 +569,10 @@ public class MigrateItemLatestVersion {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -606,10 +606,10 @@ public class MigrateItemLatestVersion {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItems.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateItems.java
@@ -132,7 +132,7 @@ public class MigrateItems {
                         RegItemclasstype regItemclasstypeItem = regItemclasstypeManager.getByLocalid("item");
                         regItemclass = addRegItemClassByItemclass(itemclass, procedureorder, regItemclasstypeItem, commit);
                     } catch (Exception ex) {
-                        logger.error(ex.getMessage());
+                        logger.error(ex.getMessage(), ex);
                         throw new Exception(ex.getMessage());
                     }
                 }
@@ -163,7 +163,7 @@ public class MigrateItems {
                     }
                     entityManagerRe3gistry2.getTransaction().commit();
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
                 /**
@@ -207,7 +207,7 @@ public class MigrateItems {
                                 }
                             }
                         } catch (Exception ex) {
-                            logger.error(ex.getMessage());
+                            logger.error(ex.getMessage(), ex);
                             throw new Exception(ex.getMessage());
                         }
 
@@ -217,13 +217,13 @@ public class MigrateItems {
                             }
                             entityManagerRe3gistry2.getTransaction().commit();
                         } catch (Exception ex) {
-                            logger.error(ex.getMessage());
+                            logger.error(ex.getMessage(), ex);
                             throw new Exception(ex.getMessage());
                         }
 
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                 }
             }
 
@@ -316,7 +316,7 @@ public class MigrateItems {
                 }
                 entityManagerRe3gistry2.getTransaction().commit();
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
 
@@ -370,7 +370,7 @@ public class MigrateItems {
                         }
                         entityManagerRe3gistry2.getTransaction().commit();
                     } catch (Exception ex) {
-                        logger.error(ex.getMessage());
+                        logger.error(ex.getMessage(), ex);
                         throw new Exception(ex.getMessage());
                     }
                 }
@@ -443,7 +443,7 @@ public class MigrateItems {
                         }
                         entityManagerRe3gistry2.getTransaction().commit();
                     } catch (Exception ex) {
-                        logger.error(ex.getMessage());
+                        logger.error(ex.getMessage(), ex);
                         throw new Exception(ex.getMessage());
                     }
                 }
@@ -484,7 +484,7 @@ public class MigrateItems {
             regItem = regItemManager.get(uuid);
 
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return regItem;
@@ -520,7 +520,7 @@ public class MigrateItems {
             regItemhistory = regItemhistoryManager.get(uuid);
 
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return regItemhistory;
@@ -587,7 +587,7 @@ public class MigrateItems {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
         return regItemclass;
@@ -730,7 +730,7 @@ public class MigrateItems {
                     throw new Exception(ex.getMessage());
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         }
@@ -825,7 +825,7 @@ public class MigrateItems {
                     throw new Exception(ex.getMessage());
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
             }
         }
 
@@ -877,7 +877,7 @@ public class MigrateItems {
                     entityManagerRe3gistry2.getTransaction().commit();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
         }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateLanguage.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateLanguage.java
@@ -96,13 +96,13 @@ public class MigrateLanguage {
                     entityManagerRe3gistry2.merge(reglanguagecode);
                     entityManagerRe3gistry2.getTransaction().commit();
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                 }
             }
             addLanguageIfNotExistent(languagecodeList, reglanguagecodeSet);
 
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
         }
     }
 
@@ -128,7 +128,7 @@ public class MigrateLanguage {
                     entityManagerRe3gistry2.persist(regLanguagecode);
                     entityManagerRe3gistry2.getTransaction().commit();
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                 }
             }
         }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateRegisters.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateRegisters.java
@@ -188,7 +188,7 @@ public class MigrateRegisters {
                             entityManagerRe3gistry2.getTransaction().commit();
                         }
                     } catch (Exception ex) {
-                        logger.error(ex.getMessage());
+                        logger.error(ex.getMessage(), ex);
                         throw new Exception(ex.getMessage());
                     }
 
@@ -198,7 +198,7 @@ public class MigrateRegisters {
                         }
                         entityManagerRe3gistry2.getTransaction().commit();
                     } catch (Exception ex) {
-                        logger.error(ex.getMessage());
+                        logger.error(ex.getMessage(), ex);
                         throw new Exception(ex.getMessage());
                     }
 
@@ -262,7 +262,7 @@ public class MigrateRegisters {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             }
@@ -289,7 +289,7 @@ public class MigrateRegisters {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             }
@@ -334,7 +334,7 @@ public class MigrateRegisters {
             }
             return regItemclass;
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateRegistry.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrateRegistry.java
@@ -158,7 +158,7 @@ public class MigrateRegistry {
                 }
                 entityManagerRe3gistry2.getTransaction().commit();
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
 
@@ -171,7 +171,7 @@ public class MigrateRegistry {
             });
 
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -217,7 +217,7 @@ public class MigrateRegistry {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             }
@@ -244,7 +244,7 @@ public class MigrateRegistry {
                         entityManagerRe3gistry2.getTransaction().commit();
                     }
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage());
+                    logger.error(ex.getMessage(), ex);
                     throw new Exception(ex.getMessage());
                 }
             }
@@ -283,7 +283,7 @@ public class MigrateRegistry {
             }
             return regItemclass;
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }

--- a/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrationManager.java
+++ b/sources/Re3gistry2Migration/src/main/java/eu/europa/ec/re3gistry2/migration/manager/MigrationManager.java
@@ -137,7 +137,7 @@ public class MigrationManager {
                     entityManagerRe3gistry2.getTransaction().rollback();
                 }
             } catch (Exception ex) {
-                logger.error(ex.getMessage());
+                logger.error(ex.getMessage(), ex);
                 throw new Exception(ex.getMessage());
             }
             throw new Exception(e.getMessage());
@@ -304,7 +304,7 @@ public class MigrationManager {
                 entityManagerRe3gistry2.getTransaction().commit();
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage());
+            logger.error(ex.getMessage(), ex);
             throw new Exception(ex.getMessage());
         }
     }


### PR DESCRIPTION
Update error logging so both the message and the stack trace are logged,
instead of only the message.

Method org.apache.logging.log4j.Logger.error(Object), used before in
a lot of places, only prints the message, making the log files not that
useful.