### PR TITLE
Add handling for exceptions thrown in RegInstallationStepCleanInstallationProfileHandler

### DIFF
--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
@@ -81,7 +81,13 @@ public class Install extends HttpServlet {
         }
 
         if (step.equals(BaseConstants.KEY_REQUEST_CLEAN_INSTALLATION_PROFILE)) {
+          try {
             new RegInstallationStepCleanInstallationProfileHandler(request);
+          } catch (Exception ex) {
+            Configuration.getInstance().getLogger().error(ex.getMessage(), ex);
+            step = "3";
+            request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_CLEAN_DB_ERROR, ex.getMessage());
+          }
         }
 
         boolean lastStep = false;


### PR DESCRIPTION
Make sure that an error is shown in the browser instead of a blank page.

Before:

![image](https://user-images.githubusercontent.com/11427611/140576243-85c5a344-c728-452e-aab4-67a80bef2cee.png)

After:

![image](https://user-images.githubusercontent.com/11427611/140576325-1c952ddf-dd24-4854-aa89-16cb1a695e6d.png)
