### PR TITLE
Make secure attribute on cookies configurable; add logging

### DIFF
--- a/sources/Re3gistry2-build-helper/pom.xml
+++ b/sources/Re3gistry2-build-helper/pom.xml
@@ -55,6 +55,7 @@
                 <persistence.jdbc.password>DB_PASSWORD</persistence.jdbc.password>
                 <application.rooturl>https://localhost/r3egistry2</application.rooturl> 
 				<application.releasenote.rss.path>/path/to/rss</application.releasenote.rss.path>
+				<web.session.cookie.secure>true</web.session.cookie.secure>
             </properties>
         </profile>        
         <!-- Server profile -->
@@ -69,6 +70,7 @@
                 <persistence.jdbc.password>DB_PASSWORD</persistence.jdbc.password>            
                 <application.rooturl>https://registry-test.eu/re3gistry2</application.rooturl>
                 <application.solr.isactive>false</application.solr.isactive>        
+                <web.session.cookie.secure>true</web.session.cookie.secure>
             </properties>
         </profile>     
     </profiles>

--- a/sources/Re3gistry2/pom.xml
+++ b/sources/Re3gistry2/pom.xml
@@ -75,6 +75,7 @@
                 <version>3.2.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
             </plugin>
             <plugin>

--- a/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
+++ b/sources/Re3gistry2/src/main/java/eu/europa/ec/re3gistry2/web/controller/Install.java
@@ -50,6 +50,7 @@ import org.apache.logging.log4j.Logger;
 public class Install extends HttpServlet {
 
     private void processRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Configuration.getInstance().getLogger().trace("Start processing request in " + Install.class.getName());
 
         // Init frontend servlet
         Configuration.getInstance().initServlet(request, response, true, false);
@@ -67,6 +68,8 @@ public class Install extends HttpServlet {
         if (step == null || step.length() < 1) {
             step = "1";
         }
+
+        Configuration.getInstance().getLogger().debug("install step = " + step);
 
         if (step.equals("2")) {
             request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_ADMIN_USER_ERROR, BaseConstants.KEY_REQUEST_USER_CREATION_STARTED);
@@ -95,11 +98,13 @@ public class Install extends HttpServlet {
             try {
                 new RegInstallationStepCleanInstallationSummaryHandler(request);
             } catch (Exception ex) {
+                Configuration.getInstance().getLogger().error(ex.getMessage(), ex);
                 step = BaseConstants.KEY_REQUEST_CLEAN_INSTALLATION_SUMMARY;
                 request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_CLEAN_DB_ERROR, ex.getMessage());
             }
         }
         if (step.equals(BaseConstants.KEY_REQUEST_CLEAN_INSTALLATION_PROCESS)) {
+            Configuration.getInstance().getLogger().info("Start clean installation");
             try {
                 createSystemInstallingFile();
                 new RegInstallationStepCleanInstallationProcessHandler(request, entityManagerRe3gistry2);
@@ -110,7 +115,9 @@ public class Install extends HttpServlet {
                     session.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS, BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS);
                 }
                 request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS, BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS);
+                Configuration.getInstance().getLogger().info("Installation succeeded");
             } catch (Exception ex) {
+                Configuration.getInstance().getLogger().error("Exception occurred in step " + BaseConstants.KEY_REQUEST_CLEAN_INSTALLATION_PROCESS, ex);
                 step = "3";
                 deleteSystemInstallingFile();
                 request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_CLEAN_DB_ERROR, ex.getMessage());
@@ -121,6 +128,7 @@ public class Install extends HttpServlet {
             try {
                 new RegInstallationStepMigrationSummaryHandler(request, entityManagerRe3gistry2);
             } catch (Exception ex) {
+                Configuration.getInstance().getLogger().error("Exception occurred in step " + BaseConstants.KEY_REQUEST_MIGRATION_SUMMARY, ex);
                 step = "3";
                 request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_MIGRATION_ERROR, ex.getMessage());
             }
@@ -137,6 +145,7 @@ public class Install extends HttpServlet {
                     session.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS, BaseConstants.KEY_REQUEST_INSTALLATION_SUCCESS);
                 }
             } catch (Exception ex) {
+                Configuration.getInstance().getLogger().error("Exception occurred in step " + BaseConstants.KEY_REQUEST_MIGRATION_PROCESS, ex);
                 step = "3";
                 deleteSystemInstallingFile();
                 request.setAttribute(BaseConstants.KEY_REQUEST_INSTALLATION_MIGRATION_ERROR, ex.getMessage());
@@ -174,19 +183,20 @@ public class Install extends HttpServlet {
 
     private void createSystemInstallingFile() throws Exception {
         String propertiesPath = System.getProperty(BaseConstants.KEY_FOLDER_NAME_CONFIGURATIONS);
-        String systemInstalledPath = propertiesPath + File.separator + BaseConstants.KEY_FILE_NAME_SYSTEMINSTALLING;
-        File systemInstalledFile = new File(systemInstalledPath);
+        String systemInstallingPath = propertiesPath + File.separator + BaseConstants.KEY_FILE_NAME_SYSTEMINSTALLING;
+        File systemInstallingFile = new File(systemInstallingPath);
 
-        systemInstalledFile.getParentFile().mkdirs();
+        systemInstallingFile.getParentFile().mkdirs();
         try {
 
-            boolean success = systemInstalledFile.createNewFile();
+            boolean success = systemInstallingFile.createNewFile();
 
             if (!success) {
                 throw new IOException();
             }
 
         } catch (IOException ex) {
+            Configuration.getInstance().getLogger().error("Error while trying to create the system installing file", ex);
             throw new Exception(ex.getMessage());
         }
     }
@@ -200,6 +210,7 @@ public class Install extends HttpServlet {
         try {
             success = file.delete();
         } catch (Exception e) {
+          Configuration.getInstance().getLogger().error("Error while trying to delete the system installing file", e);
         }
 
 //        if (!success) {
@@ -221,6 +232,7 @@ public class Install extends HttpServlet {
             }
 
         } catch (IOException ex) {
+            Configuration.getInstance().getLogger().error("Error while trying to create the system installed file", ex);
             throw new Exception(ex.getMessage());
         }
     }

--- a/sources/Re3gistry2/src/main/webapp/WEB-INF/web.xml
+++ b/sources/Re3gistry2/src/main/webapp/WEB-INF/web.xml
@@ -3,8 +3,14 @@
     <display-name>Re3gistry2</display-name>
     <session-config>
         <cookie-config>
+            <!-- A cookie with the HttpOnly attribute is inaccessible to the JavaScript Document.cookie API; it's only sent to the server. -->
             <http-only>true</http-only>
-            <secure>true</secure>
+            <!-- A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. 
+            It is strongly recommended to set this to true in a production environment; it may be set to false in an internal test environment
+            where HTTP is used instead of HTTPS. -->
+            <secure>${web.session.cookie.secure}</secure>
+            <!-- See more info on https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies
+            and on on https://www.freecodecamp.org/news/session-hijacking-and-how-to-stop-it-711e3683d1ac/ -->
         </cookie-config>
     </session-config>
     <!--Configurations-->


### PR DESCRIPTION
Using the web.xml configuration below fixes #78 

```
<session-config>
	<cookie-config>
		<http-only>true</http-only>
		<secure>false</secure>
	</cookie-config>
</session-config>
```

Compare with https://github.com/ec-jrc/re3gistry/blob/de5aba25f8623158a4929e83d3adbda2bfc7eb75/sources/Re3gistry2/src/main/webapp/WEB-INF/web.xml#L4-L9.

This pull request makes it configurable (via Maven profiles) whether the secure attribute is set:

```
<session-config>
	<cookie-config>
		<http-only>true</http-only>
		<secure>${web.session.cookie.secure}</secure>
	</cookie-config>
</session-config>
```