### PR TITLE
Update JSONFormatter to fix `thisversion`.

### DIFF
--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/JSONFormatter.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/JSONFormatter.java
@@ -225,7 +225,7 @@ public class JSONFormatter implements Formatter {
         VersionInformation version = item.getVersion();
 
         regItemJsonObject.put("id", item.getUri());
-        regItemJsonObject.put("thisversion", version.getUri() + ":" + version.getNumber());
+        regItemJsonObject.put("thisversion", version.getUri());
         regItemJsonObject.put("latestversion", item.getUri());
         if (!versionHistory.isEmpty()) {
             JSONArray previousversionsArray = new JSONArray();


### PR DESCRIPTION
Before:

```json
"latestversion": "https://mydomain.org/mylist/mylocalid",
"thisversion": "https://mydomain.org/mylist/mylocalid:1:1",
```

Now:
```json
"latestversion": "https://mydomain.org/mylist/mylocalid",
"thisversion": "https://mydomain.org/mylist/mylocalid:1",
```