### PR TITLE
Set eclipselink.ddl-generation to none instead of create-tables,

### DIFF
--- a/dist/app/re3gistry2/WEB-INF/classes/META-INF/persistence.xml.orig
+++ b/dist/app/re3gistry2/WEB-INF/classes/META-INF/persistence.xml.orig
@@ -38,7 +38,7 @@
             <property name="javax.persistence.jdbc.password" value="dbpassword"/>
             <property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver"/>
             <property name="javax.persistence.jdbc.user" value="dbuser"/>
-            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation" value="none"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/dist/app/re3gistry2restapi/WEB-INF/classes/META-INF/persistence.xml.orig
+++ b/dist/app/re3gistry2restapi/WEB-INF/classes/META-INF/persistence.xml.orig
@@ -38,7 +38,7 @@
             <property name="javax.persistence.jdbc.password" value="dbpassword"/>
             <property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver"/>
             <property name="javax.persistence.jdbc.user" value="dbuser"/>
-            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation" value="none"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/sources/Re3gistry2-build-helper/pom.xml
+++ b/sources/Re3gistry2-build-helper/pom.xml
@@ -14,7 +14,7 @@
         <persistence.unitname>Re3gistry2</persistence.unitname>
         <persistence.transactiontpye>RESOURCE_LOCAL</persistence.transactiontpye>        
         <persistence.jdbc.driver>org.postgresql.Driver</persistence.jdbc.driver>
-        <persistence.eclipselink.ddl-generation>create-tables</persistence.eclipselink.ddl-generation>
+        <persistence.eclipselink.ddl-generation>none</persistence.eclipselink.ddl-generation>
         <persistence.dependency.postgres.version>9.4.1212</persistence.dependency.postgres.version>
         <persistence.jdbc.driver>org.postgresql.Driver</persistence.jdbc.driver>
         <analytics.id></analytics.id>


### PR DESCRIPTION
as the tables are not created using EclipseLink.

Fixes #72.