### PR TITLE
Upgrade to v2.14.1 of org.apache.logging.log4j jars, add log4j-web

### DIFF
--- a/sources/Re3gistry2Base/pom.xml
+++ b/sources/Re3gistry2Base/pom.xml
@@ -60,12 +60,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8</version>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
With the older jars, the following error message appeared:

ERROR StatusLogger Log4j2 could not find a logging implementation.
Please add log4j-core to the classpath. Using SimpleLogger to log to
the console…

With v2.14.1 of log4j-api and log4j-core, that error was solved, but
then the following message appeared:

INFO StatusLogger Log4j appears to be running in a Servlet
environment, but there's no log4j-web module available. If you want
better web container support, please add the log4j-web JAR to your
web archive or server lib directory.

Therefore log4j-web was added as well.