### PR TITLE
Introduce property application.solr.version

### DIFF
--- a/sources/Re3gistry2-build-helper/pom.xml
+++ b/sources/Re3gistry2-build-helper/pom.xml
@@ -31,6 +31,7 @@
         <application.solr.url>http://localhost:8983/solr/</application.solr.url>
         <application.solr.core>re3gistry2</application.solr.core>
         <application.solr.isactive>true</application.solr.isactive>
+        <application.solr.version>8.0.0</application.solr.version>
     </properties>
     <modules>
         <module>../Re3gistry2Model</module>

--- a/sources/Re3gistry2JavaAPI/pom.xml
+++ b/sources/Re3gistry2JavaAPI/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>8.0.0</version>
+            <version>${application.solr.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Introduce property application.solr.version, so that the Solrj
dependency can be configured to have the exact same version as the
installed Solr server.