### PR TITLE
Add properties related to EclipseLink in persistence.xml

### DIFF
--- a/sources/Re3gistry2-build-helper/pom.xml
+++ b/sources/Re3gistry2-build-helper/pom.xml
@@ -17,9 +17,7 @@
         <persistence.eclipselink.ddl-generation>none</persistence.eclipselink.ddl-generation>
         <persistence.eclipselink.logging.level>CONFIG</persistence.eclipselink.logging.level>
         <persistence.eclipselink.logging.parameters>false</persistence.eclipselink.logging.parameters>
-        <persistence.eclipselink.ddl-generation>none</persistence.eclipselink.ddl-generation>
         <persistence.dependency.postgres.version>9.4.1212</persistence.dependency.postgres.version>
-        <persistence.jdbc.driver>org.postgresql.Driver</persistence.jdbc.driver>
         <analytics.id></analytics.id>
         <analytics.url></analytics.url>
         <header.message.class></header.message.class>

--- a/sources/Re3gistry2-build-helper/pom.xml
+++ b/sources/Re3gistry2-build-helper/pom.xml
@@ -15,6 +15,8 @@
         <persistence.transactiontpye>RESOURCE_LOCAL</persistence.transactiontpye>        
         <persistence.jdbc.driver>org.postgresql.Driver</persistence.jdbc.driver>
         <persistence.eclipselink.ddl-generation>create-tables</persistence.eclipselink.ddl-generation>
+        <persistence.eclipselink.logging.level>CONFIG</persistence.eclipselink.logging.level>
+        <persistence.eclipselink.logging.parameters>false</persistence.eclipselink.logging.parameters>
         <persistence.dependency.postgres.version>9.4.1212</persistence.dependency.postgres.version>
         <persistence.jdbc.driver>org.postgresql.Driver</persistence.jdbc.driver>
         <analytics.id></analytics.id>
@@ -53,6 +55,7 @@
                 <persistence.jdbc.url>jdbc:postgresql://${persistence.db.address}:${persistence.db.port}/${persistence.db.name}</persistence.jdbc.url>              
                 <persistence.jdbc.username>DB_USERNAME</persistence.jdbc.username>
                 <persistence.jdbc.password>DB_PASSWORD</persistence.jdbc.password>
+                <persistence.eclipselink.logging.file>path/to/catalina/base/logs/eclipselink.log</persistence.eclipselink.logging.file>
                 <application.rooturl>https://localhost/r3egistry2</application.rooturl> 
 				<application.releasenote.rss.path>/path/to/rss</application.releasenote.rss.path>
 				<web.session.cookie.secure>true</web.session.cookie.secure>
@@ -68,6 +71,7 @@
 				<persistence.jdbc.url>jdbc:postgresql://${persistence.db.address}:${persistence.db.port}/${persistence.db.name}</persistence.jdbc.url>              
                 <persistence.jdbc.username>DB_USERNAME</persistence.jdbc.username>
                 <persistence.jdbc.password>DB_PASSWORD</persistence.jdbc.password>            
+                <persistence.eclipselink.logging.file>path/to/catalina/base/logs/eclipselink.log</persistence.eclipselink.logging.file>
                 <application.rooturl>https://registry-test.eu/re3gistry2</application.rooturl>
                 <application.solr.isactive>false</application.solr.isactive>        
                 <web.session.cookie.secure>true</web.session.cookie.secure>

--- a/sources/Re3gistry2/src/main/resources/META-INF/persistence.xml
+++ b/sources/Re3gistry2/src/main/resources/META-INF/persistence.xml
@@ -39,6 +39,10 @@
             <property name="javax.persistence.jdbc.driver" value="${persistence.jdbc.driver}"/>
             <property name="javax.persistence.jdbc.user" value="${persistence.jdbc.username}"/>
             <property name="eclipselink.ddl-generation" value="${persistence.eclipselink.ddl-generation}"/>
+            <property name="eclipselink.logging.level" value="${persistence.eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.level.sql" value="${persistence.eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.parameters" value="${persistence.eclipselink.logging.parameters}"/>
+            <property name="eclipselink.logging.file" value="${persistence.eclipselink.logging.file}"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/sources/Re3gistry2RestAPI/src/main/resources/META-INF/persistence.xml
+++ b/sources/Re3gistry2RestAPI/src/main/resources/META-INF/persistence.xml
@@ -39,6 +39,10 @@
             <property name="javax.persistence.jdbc.driver" value="${persistence.jdbc.driver}"/>
             <property name="javax.persistence.jdbc.user" value="${persistence.jdbc.username}"/>
             <property name="eclipselink.ddl-generation" value="${persistence.eclipselink.ddl-generation}"/>
+            <property name="eclipselink.logging.level" value="${persistence.eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.level.sql" value="${persistence.eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.parameters" value="${persistence.eclipselink.logging.parameters}"/>
+            <property name="eclipselink.logging.file" value="${persistence.eclipselink.logging.file}"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
The following properties are set in persistence.xml during the build:

- eclipselink.logging.level (from property persistence.eclipselink.logging.level)
- eclipselink.logging.level.sql (also from property persistence.eclipselink.logging.level)
- eclipselink.logging.parameters (from property persistence.eclipselink.logging.parameters)
- eclipselink.logging.file (from property persistence.eclipselink.logging.file)

See also https://wiki.eclipse.org/EclipseLink/Examples/JPA/Logging.