### PR TITLE
Correct name of logger; fix bug with logger that is null when error

### DIFF
--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/CacheAllServlet.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/CacheAllServlet.java
@@ -48,21 +48,19 @@ import java.util.concurrent.Future;
 
 public class CacheAllServlet extends HttpServlet {
 
-    private static final Logger LOG = LogManager.getLogger(CacheServlet.class.getName());
+    private static final Logger LOG = LogManager.getLogger(CacheAllServlet.class.getName());
     private static final long serialVersionUID = 1L;
 
     private EntityManagerFactory emf;
     private ItemCache cache;
-    private Logger logger;
 
     @Override
     public void init(ServletConfig config) throws ServletException {
         try {
             this.emf = PersistenceFactory.getEntityManagerFactory();
             this.cache = (ItemCache) config.getServletContext().getAttribute(CacheServlet.ATTRIBUTE_CACHE_KEY);
-            this.logger = LogManager.getLogger("Re3gistry2");
         } catch (Exception e) {
-            this.logger.error("Unexpected exception occured: cannot load the configuration system", e);
+            LOG.error("Unexpected exception occured: cannot load the configuration system", e);
         }
     }
 
@@ -78,10 +76,11 @@ public class CacheAllServlet extends HttpServlet {
             ExecutorService executor = Executors.newFixedThreadPool(availableLanguages.size());
 
             for (RegLanguagecode languageCode : availableLanguages) {
-                Future result = executor.submit(new CacheAll(this.emf, this.cache, this.logger, languageCode));
+                Future result = executor.submit(new CacheAll(this.emf, this.cache, LOG, languageCode));
             }
             executor.shutdown();
         } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
         }
     }
 }

--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/CacheServlet.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/CacheServlet.java
@@ -45,7 +45,7 @@ import org.apache.logging.log4j.Logger;
 public class CacheServlet extends HttpServlet {
 
     static final String ATTRIBUTE_CACHE_KEY = "re3gistry-rest-api-cache";
-    private static final Logger LOG = LogManager.getLogger(ItemsServlet.class.getName());
+    private static final Logger LOG = LogManager.getLogger(CacheServlet.class.getName());
     private static final long serialVersionUID = 1L;
 
     private static ItemCache cache;


### PR DESCRIPTION
Correct the names of the loggers in CacheServlet and CacheAllServlet.
Make sure that those loggers are used.

With the previous code, a `NullPointerException` was thrown on line 65 when `PersistenceFactory.getEntityManagerFactory()` threw an exception, because the variable that was used for logging that error was still null (only initialized on line 63).

https://github.com/ec-jrc/re3gistry/blob/d01e317dd9b820daebd9cd0bf95225ff4c76cb7e/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/CacheAllServlet.java#L60-L66

