### PR TITLE
Bump log4j-web from 2.14.1 to 2.15.0

### DIFF
--- a/sources/Re3gistry2Base/pom.xml
+++ b/sources/Re3gistry2Base/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Complements #116 and #117, for some reason dependabot didn't catch this one?

See also https://nvd.nist.gov/vuln/detail/CVE-2021-44228 and https://logging.apache.org/log4j/2.x/security.html.