### PR TITLE
Updating avaliableFormatsUtil and fixing Atom format content type

### DIFF
--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/ATOMFormatter.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/ATOMFormatter.java
@@ -57,7 +57,7 @@ public class ATOMFormatter implements Formatter {
 
     @Override
     public String getContentType() {
-        return "text/xml";
+        return "text/atom+xml";
     }
 
     @Override

--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/util/AvailableFormatsUtil.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/util/AvailableFormatsUtil.java
@@ -19,6 +19,8 @@ public class AvailableFormatsUtil {
         formatList.add("iso19135xml");
         formatList.add("rdf");
         formatList.add("csv");
+        formatList.add("Atom");
+        formatList.add("Ror");
     }
 
     public List<String> getFormatList() {


### PR DESCRIPTION
235:he new formats that has been included in the Re3gistry software are not added to this class.

Missing formats:

Atom
Ror
This list of formats is used to generate the Rdf (RdfFormatter:563).

236: Atom format content type is set to "text/xml" in the class AtomFormatter getContentType method. This content type should be "text/atom+xml" as is use in different parts of the Re3gistry software.