### PR TITLE
Improve labels on install UI

### DIFF
--- a/sources/Re3gistry2/src/main/resources/localizations/LocalizationBundle_en.properties
+++ b/sources/Re3gistry2/src/main/resources/localizations/LocalizationBundle_en.properties
@@ -531,9 +531,9 @@ installation.choose.master.language=Choose the master language
 installation.choose.master.language.description=The master language is the one used by the Re3gistry to handle multilingualism. <i>Note that this will require all content to be available in the chosen master language.</i>
 
 installation.clean.registry.localid=Local ID
-installation.clean.registry.localid.description=The local ID will be part of the public URL, generally the path following the domain name: <b>http://example.com</b>/registry 
+installation.clean.registry.localid.description=The local ID will be part of the public URL, generally the path following the domain name: http://example.com/<b>registry</b>
 installation.clean.registry.baseuri=Base URI
-installation.clean.registry.baseuri.description=The base URI will be part of the public URL, generally this should match with your own domain name: http://example.com/<b>registry</b>
+installation.clean.registry.baseuri.description=The base URI will be part of the public URL, generally this should match with your own domain name: <b>http://example.com</b>/registry
 installation.clean.registry.id=ID
 installation.clean.registry.label=Label
 installation.clean.registry.label.description=The label of the registry will be the \u2018title\u2019 of the Re3gistry instance. It will be shown in the registry\u2019s landing page.


### PR DESCRIPTION
Bolded parts of the message were the wrong ones (as far as I know). On local ID the domain was bolded and on Base URI the path part of the URL was bolded. Switching them.

![image](https://github.com/ec-jrc/re3gistry/assets/2210335/441250fe-1655-4c72-8cd9-6ada5c8b4e6a)
