### PR TITLE
Add conf value for static resources/logos

### DIFF
--- a/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
@@ -27,4 +27,5 @@ registryApp.hostURL = '//registry-test.eu/registry';
 registryApp.searchURL = '//registry-test.eu/registry/search';
 registryApp.searchApiURL = '//registry-test.eu/registry/searchapi';
 registryApp.dataServiceURL = '//registry-test.eu/registry/rest';
-
+// required for logo to work
+registryApp.staticResourcesPath = '/ecl-v2/static/logo/';

--- a/sources/Re3gistry2ServiceWebapp/public_html/index.html
+++ b/sources/Re3gistry2ServiceWebapp/public_html/index.html
@@ -64,7 +64,7 @@
                 <div class="ecl-site-header__banner">
                     <a data-i18n-link="l-ec-website" class="ecl-link ecl-link--standalone" href="https://inspire-sandbox.jrc.ec.europa.eu/registry"
                        aria-label="European Commission">
-                        <img class="mb-2" src="/registry/ecl-v2/static/logo/logo-1.png" alt="" width="50%" height="50%">
+                        <img class="mb-2 ecl-site-header__logo-image" src="/registry/ecl-v2/static/logo/logo-1.png" alt="" width="50%" height="50%">
                     </a>
                     <!-- <div >
                         <h3><a href="https://github.com/ec-jrc/re3gistry" style="


### PR DESCRIPTION
Makes the header logo work on the frontend app:
![image](https://github.com/ec-jrc/re3gistry/assets/2210335/5ee065ac-cc21-47fb-b819-3d6cd7b23330)

-> 

![image](https://github.com/ec-jrc/re3gistry/assets/2210335/fae65efb-3fcb-4e25-b292-0db5fece3b69)

However there is a reference to icons.svg that uses the same path variable, but the icons.svg is under `/ecl-v2/static/media`. Not sure where that one is shown but it's not possible to make it work on both cases without changes to `js-ecl-v2/app_i18n.js`:

https://github.com/ec-jrc/re3gistry/blob/v2.5.2/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_i18n.js#L27C165-L27C209

and https://github.com/ec-jrc/re3gistry/blob/v2.5.2/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_i18n.js#L189
