### PR TITLE
Fix restapi NPE on missing config

### DIFF
--- a/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/XMLFormatter.java
+++ b/sources/Re3gistry2RestAPI/src/main/java/eu/europa/ec/re3gistry2/restapi/format/XMLFormatter.java
@@ -319,7 +319,7 @@ public class XMLFormatter implements Formatter {
                     writeComplexListElement(xml, localizedProperty, lang, "predecessors", fieldLocalId);
                 } else if (fieldName != null && "parent".equals(fieldLocalId)) {
                     writeComplexListElement(xml, localizedProperty, lang, "parents", fieldLocalId);
-                } else if (!legacyFlag.equals(BaseConstants.KEY_APPLICATION_LEGACY_FLAG_ON)) {
+                } else if (!BaseConstants.KEY_APPLICATION_LEGACY_FLAG_ON.equals(legacyFlag)) {
                     if (href != null && !href.isEmpty()) {
                         xml.writeStartElement(fieldLocalId);
                         xml.writeAttribute("id", href);


### PR DESCRIPTION
Currently the restapi webapp throws a NullPointerException if the configuration.properties doesn't have the property `application.legacy.flag=[something]` defined. This makes it work without the config.