### PR TITLE
Frontend configuration instructions and adding config for the default URI

### DIFF
--- a/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
@@ -18,13 +18,18 @@ registryApp.forceHttpURIs=true;
 registryApp.errorMessageDefinition = "Re3gistry Software repository";
 registryApp.errorMessageURL = "https://github.com/ec-jrc/re3gistry";
 
+var myDomain = "//registry-test.eu";
 // Default backend link (To put on links and access to the admin interface)
-registryApp.backendURL = "//localhost:8080/re3gistry2";
+registryApp.backendURL = myDomain + "/re3gistry2";
 
 // The app's base URL
-registryApp.domainURL = '//registry-test.eu';
-registryApp.hostURL = '//registry-test.eu/registry';
-registryApp.searchURL = '//registry-test.eu/registry/search';
-registryApp.searchApiURL = '//registry-test.eu/registry/searchapi';
-registryApp.dataServiceURL = '//registry-test.eu/registry/rest';
-
+registryApp.domainURL = myDomain;
+registryApp.frontendPath = '/registry';
+registryApp.hostURL = registryApp.domainURL + registryApp.frontendPath;
+registryApp.searchURL = registryApp.hostURL + '/search';
+// should point towards /solr/re3gistry2/select
+registryApp.searchApiURL = registryApp.hostURL + '/searchapi';
+// should point towards /re3gistry2restapi/items/any webapp url/or forward to it
+registryApp.dataServiceURL = registryApp.hostURL + '/re3gistry2restapi/items/any';
+// should be the URI for the base registry in re3gistry2 webapp (defaults to frontend URL)
+registryApp.defaultRegisterURI = registryApp.hostURL;

--- a/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
@@ -18,18 +18,16 @@ registryApp.forceHttpURIs=true;
 registryApp.errorMessageDefinition = "Re3gistry Software repository";
 registryApp.errorMessageURL = "https://github.com/ec-jrc/re3gistry";
 
-var myDomain = "//registry-test.eu";
 // Default backend link (To put on links and access to the admin interface)
-registryApp.backendURL = myDomain + "/re3gistry2";
+registryApp.backendURL = "//registry-test.eu/re3gistry2";
 
 // The app's base URL
-registryApp.domainURL = myDomain;
-registryApp.frontendPath = '/registry';
-registryApp.hostURL = registryApp.domainURL + registryApp.frontendPath;
-registryApp.searchURL = registryApp.hostURL + '/search';
+registryApp.domainURL = '//registry-test.eu';
+registryApp.hostURL = '//registry-test.eu/registry';
+registryApp.searchURL = '//registry-test.eu/registry/search';
 // should point towards /solr/re3gistry2/select
-registryApp.searchApiURL = registryApp.hostURL + '/searchapi';
+registryApp.searchApiURL = '//registry-test.eu/registry/searchapi';
 // should point towards /re3gistry2restapi/items/any webapp url/or forward to it
-registryApp.dataServiceURL = registryApp.hostURL + '/re3gistry2restapi/items/any';
+registryApp.dataServiceURL = '//registry-test.eu/registry/rest';
 // should be the URI for the base registry in re3gistry2 webapp (defaults to frontend URL)
 registryApp.defaultRegisterURI = registryApp.hostURL;

--- a/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/conf/conf.js
@@ -23,11 +23,13 @@ registryApp.backendURL = "//registry-test.eu/re3gistry2";
 
 // The app's base URL
 registryApp.domainURL = '//registry-test.eu';
+// the path where the frontend app is located in (Note! there are hardcoded refs to /registry path as well)
 registryApp.hostURL = '//registry-test.eu/registry';
+// requires forward/redirect to search.html on httpd
 registryApp.searchURL = '//registry-test.eu/registry/search';
-// should point towards /solr/re3gistry2/select
+// requires forward/redirect to /solr/re3gistry2/select on httpd
 registryApp.searchApiURL = '//registry-test.eu/registry/searchapi';
-// should point towards /re3gistry2restapi/items/any webapp url/or forward to it
+// requires forward/redirect to /re3gistry2restapi/items/any webapp on httpd
 registryApp.dataServiceURL = '//registry-test.eu/registry/rest';
-// should be the URI for the base registry in re3gistry2 webapp (defaults to frontend URL)
+// should match the URI for the base registry in re3gistry2 webapp (defaults to frontend URL)
 registryApp.defaultRegisterURI = registryApp.hostURL;

--- a/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
@@ -43,7 +43,7 @@ const htmlSnippet_tr = '<tr class="ecl-table__row">{0}</tr>';
 const htmlSnippet_td = '<td data-ecl-table-header="{1}" class="ecl-table__cell">{0}</td>';
 const htmlSnippet_ul = '<ul class="ecl-unordered-list ecl-unordered-list--no-bullet">{0}</ul>';
 const htmlSnippet_li = '<li class="ecl-unordered-list__item">{0}</li>';
-const htmlSnippet_href = '<a href="{0}" class="ecl-link ecl-link--standalone" onClick="fetchData(this.href);return false;">{1}</a>';
+const htmlSnippet_href = '<a href="{0}" class="ecl-link ecl-link--standalone">{1}</a>';
 const htmlSnippet_href_external_link = '<a href="{0}" class="ecl-link ecl-link--standalone">{1} <svg focusable="false" aria-hidden="true" class="ecl-link__icon ecl-icon ecl-icon--xs"><use xlink:href="' + registryApp.hostURL + registryApp.staticResourcesPath + 'icons.svg#ui--external"></use></svg></a>';
 const htmlSnippet_href_format = '<li class="ecl-social-media-follow__item"><a href="{0}" class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-before ecl-social-media-follow__link"><svg focusable="false" aria-hidden="true" class="ecl-link__icon ecl-icon ecl-icon--xs"><use xlink:href="' + registryApp.hostURL + registryApp.staticResourcesPath + 'icons.svg#general--file"></use></svg> {1}</a></li>';
 const htmlSnippet_field = '<div class="ecl-row"><div class="ecl-col-lg-3 ecl-col-sm-12 ecl-u-mv-s"><span class="ecl-u-type-m">{0}</span></div><div class="ecl-col-lg-9 ecl-col-sm-12 ecl-u-mv-s"><span class="ecl-u-type-m {2}">{1}</span></div></div>';

--- a/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
@@ -75,7 +75,7 @@ const htmlSnippet_paginationNextIcon = '<span class="ecl-link__label">{0}</span>
 function fetchData(uri, lang) {
 
     if (uri === null || typeof uri === val_undefined || uri.length === 0) {
-        uri = uriFromUrl;
+        uri = registryApp.defaultRegisterURI || uriFromUrl;
     }
 
     if (lang === null || typeof lang === val_undefined || lang.length === 0) {

--- a/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
+++ b/sources/Re3gistry2ServiceWebapp/public_html/js-ecl-v2/app_core.js
@@ -43,7 +43,7 @@ const htmlSnippet_tr = '<tr class="ecl-table__row">{0}</tr>';
 const htmlSnippet_td = '<td data-ecl-table-header="{1}" class="ecl-table__cell">{0}</td>';
 const htmlSnippet_ul = '<ul class="ecl-unordered-list ecl-unordered-list--no-bullet">{0}</ul>';
 const htmlSnippet_li = '<li class="ecl-unordered-list__item">{0}</li>';
-const htmlSnippet_href = '<a href="{0}" class="ecl-link ecl-link--standalone">{1}</a>';
+const htmlSnippet_href = '<a href="{0}" class="ecl-link ecl-link--standalone" onClick="fetchData(this.href);return false;">{1}</a>';
 const htmlSnippet_href_external_link = '<a href="{0}" class="ecl-link ecl-link--standalone">{1} <svg focusable="false" aria-hidden="true" class="ecl-link__icon ecl-icon ecl-icon--xs"><use xlink:href="' + registryApp.hostURL + registryApp.staticResourcesPath + 'icons.svg#ui--external"></use></svg></a>';
 const htmlSnippet_href_format = '<li class="ecl-social-media-follow__item"><a href="{0}" class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-before ecl-social-media-follow__link"><svg focusable="false" aria-hidden="true" class="ecl-link__icon ecl-icon ecl-icon--xs"><use xlink:href="' + registryApp.hostURL + registryApp.staticResourcesPath + 'icons.svg#general--file"></use></svg> {1}</a></li>';
 const htmlSnippet_field = '<div class="ecl-row"><div class="ecl-col-lg-3 ecl-col-sm-12 ecl-u-mv-s"><span class="ecl-u-type-m">{0}</span></div><div class="ecl-col-lg-9 ecl-col-sm-12 ecl-u-mv-s"><span class="ecl-u-type-m {2}">{1}</span></div></div>';
@@ -645,7 +645,7 @@ function renderTableProperties(data, headerProperties) {
                                             value = renderHref(tmpValue, data.uri);
                                           } else {
                                             value = renderHref(tmpValue, data.uri + "?status=" + data.properties[2].values[0].value.toLowerCase());
-                                          }   
+                                          }
                                     } else {
                                         value = renderHrefExternalLink(tmpValue, data.uri);
                                     }


### PR DESCRIPTION
- Make default URI configurable for fetching data from the rest API with `conf.js` `registryApp.defaultRegisterURI`. Currently the frontend tries to query the registry for content to show with URL where the frontend is running in by default. If the URI in the database doesn't match the frontend location, this new conf can be used to make the frontend query the correct URI for the default listing.
- Add comments where paths  in`conf.js` should point to/be redirected to on httpd.